### PR TITLE
Fallback to server name if host header not present

### DIFF
--- a/aikido_firewall/context/wsgi/build_url_from_wsgi.py
+++ b/aikido_firewall/context/wsgi/build_url_from_wsgi.py
@@ -5,14 +5,14 @@ def build_url_from_wsgi(request):
     """Builds a URL from the different parts in a WSGI request"""
     scheme = request["wsgi.url_scheme"]
     uri = request["PATH_INFO"]
-    
+
     host = ""
     if "HTTP_HOST" not in request or request["HTTP_HOST"] == "":
         host = request["SERVER_NAME"]
         port = request["SERVER_PORT"]
-        
+
         host = f"{host}:{port}"
     else:
         host = request["HTTP_HOST"]
-    
+
     return f"{scheme}://{host}{uri}"

--- a/aikido_firewall/context/wsgi/build_url_from_wsgi_test.py
+++ b/aikido_firewall/context/wsgi/build_url_from_wsgi_test.py
@@ -22,6 +22,29 @@ def test_build_url_from_wsgi_https():
     assert build_url_from_wsgi(request) == expected
 
 
+def test_build_url_from_wsgi_with_missing_hostname():
+    request = {
+        "wsgi.url_scheme": "https",
+        "SERVER_NAME": "127.0.0.1",
+        "SERVER_PORT": 1337,
+        "PATH_INFO": "/secure/resource",
+    }
+    expected = "https://127.0.0.1:1337/secure/resource"
+    assert build_url_from_wsgi(request) == expected
+
+
+def test_build_url_from_wsgi_with_empty_hostname():
+    request = {
+        "wsgi.url_scheme": "https",
+        "HTTP_HOST": "",
+        "SERVER_NAME": "127.0.0.1",
+        "SERVER_PORT": 1337,
+        "PATH_INFO": "/secure/resource",
+    }
+    expected = "https://127.0.0.1:1337/secure/resource"
+    assert build_url_from_wsgi(request) == expected
+
+
 def test_build_url_from_wsgi_with_query_string():
     request = {
         "wsgi.url_scheme": "http",


### PR DESCRIPTION
When HTTP_HOST was not found in the request, this function would throw an exception because `HTTP_HOST` would not be present inside `request`. This would then keep the context empty, as `build_url_from_wsgi` is called by `set_wsgi_attributes_on_context` (which would then fail to complete).
