### PR TITLE
Return None if port is invalid

### DIFF
--- a/aikido_firewall/helpers/get_port_from_url.py
+++ b/aikido_firewall/helpers/get_port_from_url.py
@@ -14,9 +14,15 @@ def get_port_from_url(url, parsed=False):
     else:
         parsed_url = url
 
-    # Check if the port is specified and is a valid integer
-    if parsed_url.port is not None:
-        return parsed_url.port
+    try:
+        # Check if the port is specified and is a valid integer
+        if parsed_url.port is not None:
+            return parsed_url.port
+    except ValueError:
+        # This can happen if someone provides an invalid port, or if port is out of range
+        # https://github.com/python/cpython/blob/fb1b51a58df4315f7ef3171a5abeb74f132b0971/Lib/urllib/parse.py#L184
+        # Return None, in order to ensure we still match the hostname.
+        return None
 
     # Determine the default port based on the protocol
     if parsed_url.scheme == "https":

--- a/aikido_firewall/helpers/get_port_from_url_test.py
+++ b/aikido_firewall/helpers/get_port_from_url_test.py
@@ -9,6 +9,8 @@ def test_get_port_from_url():
     assert get_port_from_url("https://test.com:8080/test?abc=123") == 8080
     assert get_port_from_url("https://localhost") == 443
     assert get_port_from_url("ftp://localhost") is None
+    assert get_port_from_url("http://localhost:1337\\u0000asd.php") is None
+    assert get_port_from_url("http://localhost:123123/asd.php") is None
 
 
 def test_get_port_from_parsed_url():
@@ -19,3 +21,5 @@ def test_get_port_from_parsed_url():
     )
     assert get_port_from_url(urlparse("https://localhost"), True) == 443
     assert get_port_from_url(urlparse("ftp://localhost"), True) is None
+    assert get_port_from_url(urlparse("http://localhost:1337\\u0000asd.php")) is None
+    assert get_port_from_url(urlparse("http://localhost:123123/asd.php")) is None

--- a/aikido_firewall/vulnerabilities/ssrf/find_hostname_in_userinput_test.py
+++ b/aikido_firewall/vulnerabilities/ssrf/find_hostname_in_userinput_test.py
@@ -73,6 +73,15 @@ def test_it_finds_ip_address_with_strange_notation_inside_url():
     assert find_hostname_in_userinput("http://127.0.1", "127.0.1") is True
 
 
+def test_it_works_with_invalid_ports():
+    assert (
+        find_hostname_in_userinput(
+            "http://localhost:1337\\u0000asd.php", "localhost", 1337
+        )
+        is True
+    )
+
+
 def test_it_works_with_ports():
     assert find_hostname_in_userinput("http://localhost", "localhost", 8080) is False
     assert (


### PR DESCRIPTION
The `.port` property runs additional assertions as seen at https://github.com/python/cpython/blob/fb1b51a58df4315f7ef3171a5abeb74f132b0971/Lib/urllib/parse.py#L184.

Since requests, urllib3, and other libraries just check if the URL can be parsed via urllib.parse(...), they don't run into these additional assertions (port number is extracted from the host without any assertions: https://github.com/python/cpython/blob/fb1b51a58df4315f7ef3171a5abeb74f132b0971/Lib/urllib/parse.py#L237).