### PR TITLE
Make sure body is not a byte string, so data remains serializable

### DIFF
--- a/aikido_zen/sources/django/run_init_stage.py
+++ b/aikido_zen/sources/django/run_init_stage.py
@@ -22,7 +22,8 @@ def run_init_stage(request):
             # During a GET request, django leaves the body as an empty byte string (e.g. `b''`).
             # When an attack is detected, this body needs to be serialized which would fail.
             # So a byte string gets converted into a string to stop that from happening.
-            body = ""; # Set body to an empty string.
+            body = ""
+            # Set body to an empty string.
 
         context = None
         if hasattr(request, "scope"):  # This request is an ASGI request


### PR DESCRIPTION
During a GET request, django leaves the body as an empty byte string (e.g. `b''`). When an attack is detected, this body needs to be serialized, which then fails with `Object of type bytes is not JSON serializable`. 

In order to fix this, we check and make sure that the body is not a bytestring.