### PR TITLE
Remove flask dev server warning

### DIFF
--- a/docs/flask.md
+++ b/docs/flask.md
@@ -1,8 +1,5 @@
 # Flask
 
-> [!WARNING]
-> The Flask development server is not fully supported and may report incomplete data, we recommend using a web server like [gUnicorn](./gunicorn.md) to test all features Zen has to offer.
-
 ## Installation
 
 1. Install `aikido_zen` package with pip :


### PR DESCRIPTION
Warning can be removed, this warning was added before adding the process worker logic, which was meant to fix issues like this one.