### PR TITLE
Only patch chown if chown exists

### DIFF
--- a/aikido_zen/sinks/os.py
+++ b/aikido_zen/sinks/os.py
@@ -1,6 +1,7 @@
 """
 Sink module for python's `os`
 """
+
 import os
 from pathlib import PurePath
 import aikido_zen.vulnerabilities as vulns


### PR DESCRIPTION
The only reason is to avoid an error message in the logs, functionally it's still the same