### PR TITLE
Update zen intenals to v0.1.44

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ benchmark:
 
 
 # Binaries cache :
-BASE_URL = https://github.com/AikidoSec/zen-internals/releases/download/v0.1.43
+BASE_URL = https://github.com/AikidoSec/zen-internals/releases/download/v0.1.44
 FILES = \
     libzen_internals_aarch64-apple-darwin.dylib \
     libzen_internals_aarch64-apple-darwin.dylib.sha256sum \


### PR DESCRIPTION
- Fixes false pos with `[]`