### PR TITLE
fix: Give default value to user.name in `set_user`

### DIFF
--- a/aikido_zen/context/users.py
+++ b/aikido_zen/context/users.py
@@ -35,7 +35,7 @@ def set_user(user):
     if cache:
         cache.users.add_user(
             user_id=validated_user["id"],
-            user_name=validated_user["name"],
+            user_name=validated_user.get("name", ""),
             user_ip=validated_user["lastIpAddress"],
             current_time=t.get_unixtime_ms(),
         )


### PR DESCRIPTION
Hi all, new to this repo and just wondering about below. Happy for any feedback

Issue:

Currently, calling `set_user({"id": "user_id"})` (not specifying name) is allowed, however `set_user` assumes that `validate_user` returns a dict with a `name` key, resulting in a `KeyError` if name is not provided.

Fix:

- Make this a required field, or
- Set default empty str to avoid raising `KeyError`
  - I believe the `Users` UI actually requires the name to be populated, otherwise it doesn't display