### PR TITLE
Make [Ctrl-C] exits with zen graceful in gUnicorn

### DIFF
--- a/aikido_zen/background_process/__init__.py
+++ b/aikido_zen/background_process/__init__.py
@@ -47,7 +47,10 @@ def start_background_process():
 
     #  Daemon is set to True so that the process kills itself when the main process dies
     background_process = Process(
-        target=AikidoBackgroundProcess, args=(comms.address, comms.key), daemon=True
+        target=AikidoBackgroundProcess,
+        args=(comms.address, comms.key),
+        name="zen-agent-process",
+        daemon=True,
     )
     background_process.start()
 

--- a/aikido_zen/background_process/aikido_background_process.py
+++ b/aikido_zen/background_process/aikido_background_process.py
@@ -41,7 +41,7 @@ class AikidoBackgroundProcess:
         self.queue = Queue()
         self.connection_manager = None
         # Start reporting thread :
-        Thread(target=self.reporting_thread).start()
+        Thread(target=self.reporting_thread, daemon=True).start()
 
         logger.debug(
             "Background process started successfully, with UDS File : %s", address

--- a/aikido_zen/background_process/aikido_background_process.py
+++ b/aikido_zen/background_process/aikido_background_process.py
@@ -3,6 +3,7 @@ Simply exports the aikido background process
 """
 
 import multiprocessing.connection as con
+import signal
 import time
 import sched
 import traceback
@@ -45,6 +46,8 @@ class AikidoBackgroundProcess:
         logger.debug(
             "Background process started successfully, with UDS File : %s", address
         )
+
+        add_exit_handlers()
 
         while True:
             conn = listener.accept()
@@ -105,3 +108,17 @@ class AikidoBackgroundProcess:
                 blocked=queue_attack_item[2],
                 stack=queue_attack_item[3],
             )
+
+
+def add_exit_handlers():
+    """
+    We add graceful exit handlers here since the process keeps hanging otherwise.
+    """
+
+    def exit_gracefully(sig, frame):
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, exit_gracefully)
+    signal.signal(signal.SIGTERM, exit_gracefully)
+    signal.signal(signal.SIGQUIT, exit_gracefully)
+    signal.signal(signal.SIGHUP, exit_gracefully)

--- a/aikido_zen/decorators/gunicorn.py
+++ b/aikido_zen/decorators/gunicorn.py
@@ -5,10 +5,6 @@ Includes all the wrappers for gunicorn config file
 import aikido_zen
 
 
-# Run our background process as a child of gunicorn (exits safely)
-aikido_zen.protect("daemon_only")
-
-
 def post_fork(prev_func):
     """
     Aikido decorator for gunicorn config
@@ -16,7 +12,7 @@ def post_fork(prev_func):
     """
 
     def aik_post_fork(server, worker):
-        aikido_zen.protect("daemon_disabled")
+        aikido_zen.protect()
         prev_func(server, worker)
 
     return aik_post_fork


### PR DESCRIPTION
Fixing error with gUnicorn [Ctrl-C], the process doesnt exit gracefully
```
[2025-09-17 13:15:55 +0200] [59997] [INFO] Handling signal: intTraceback (most recent call last):  File "/var/home/primary/.pyenv/versions/3.9.19/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap    self.run()  File "/var/home/primary/.pyenv/versions/3.9.19/lib/python3.9/multiprocessing/process.py", line 108, in run    self._target(*self._args, **self._kwargs)  File "/var/home/primary/Aikido/firewall-python/aikido_zen/background_process/aikido_background_process.py", line 50, in __init__    conn = listener.accept()  File "/var/home/primary/.pyenv/versions/3.9.19/lib/python3.9/multiprocessing/connection.py", line 463, in accept    c = self._listener.accept()  File "/var/home/primary/.pyenv/versions/3.9.19/lib/python3.9/multiprocessing/connection.py", line 609, in accept    s, self._last_accepted = self._socket.accept()  File "/var/home/primary/.pyenv/versions/3.9.19/lib/python3.9/socket.py", line 293, in accept    fd, addr = self._accept()KeyboardInterrupt[2025-09-17 13:15:55 +0200] [60078] [INFO] Worker exiting (pid: 60078)Error in atexit._run_exitfuncs:Traceback (most recent call last):  File "/var/home/primary/.pyenv/versions/3.9.19/lib/python3.9/multiprocessing/util.py", line 357, in _exit_function    p.join()  File "/var/home/primary/.pyenv/versions/3.9.19/lib/python3.9/multiprocessing/process.py", line 147, in join    assert self._parent_pid == os.getpid(), 'c
```

We fix this by not trying to start the background process outside of the forks (in `gunicorn_config.py`), and by adding graceful exit handlers to the background process