### PR TITLE
Trim user input before sending to detect_sql_injection

### DIFF
--- a/aikido_zen/vulnerabilities/sql_injection/__init__.py
+++ b/aikido_zen/vulnerabilities/sql_injection/__init__.py
@@ -16,7 +16,7 @@ def detect_sql_injection(query, user_input, dialect):
     """
     try:
         query_l = query.lower()
-        userinput_l = user_input.lower()
+        userinput_l = user_input.lower().strip()
         if should_return_early(query_l, userinput_l):
             return False
 

--- a/aikido_zen/vulnerabilities/sql_injection/init_test.py
+++ b/aikido_zen/vulnerabilities/sql_injection/init_test.py
@@ -413,6 +413,13 @@ def test_function_calls_as_sql_injections():
     is_sql_injection("€foobar()", "€foobar()")
 
 
+def test_trimmed_user_input_bypass():
+    is_sql_injection(
+        "INSERT INTO pets (name, owner) VALUES ('x', 'dummy'), ('injected', 'hacker'); --', 'owner')",
+        "x', 'dummy'), ('injected', 'hacker'); --    ",
+    )
+
+
 def file_paths():
     script_dir = os.path.dirname(__file__)
     return [


### PR DESCRIPTION
Strips leading/trailing whitespace from user input before SQL injection detection, matching the fix applied to the Java firewall in AikidoSec/firewall-java#298.

**Problem**: An attacker can pad their payload with trailing whitespace (e.g. `"payload   "`). If the DB driver trims this before execution, the SQL query won't contain the padded input, causing `should_return_early` to incorrectly return `True` (missed detection).

**Fix**: Apply `.lower().strip()` to the user input before both the early-return check and the native detection call.

See: https://github.com/AikidoSec/firewall-java/pull/298

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Trimmed and lowercased user input before SQL injection detection


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124637087?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->