### PR TITLE
Make path traversal containment check case-insensitive

### DIFF
--- a/aikido_zen/vulnerabilities/path_traversal/detect_path_traversal.py
+++ b/aikido_zen/vulnerabilities/path_traversal/detect_path_traversal.py
@@ -28,7 +28,7 @@ def detect_path_traversal(file_path, user_input, check_path_start=True, is_url=F
         # Because the user input can't be part of the file path.
         return False
 
-    if user_input not in file_path:
+    if user_input.lower() not in file_path.lower():
         # We ignore cases where the user input is not part of the file path.
         return False
 

--- a/aikido_zen/vulnerabilities/path_traversal/detect_path_traversal_test.py
+++ b/aikido_zen/vulnerabilities/path_traversal/detect_path_traversal_test.py
@@ -150,3 +150,9 @@ def test_replacement_char_prefix_does_not_hide_traversal():
         detect_path_traversal(replacement * 3 + traversal, replacement * 3 + traversal)
         is True
     )
+
+
+def test_case_insensitive_path_containment():
+    assert detect_path_traversal("/etc/passwd", "/ETC/passwd") is True
+    assert detect_path_traversal("/etc/passwd", "/ETC/PASSWD") is True
+    assert detect_path_traversal("/home/user/file.txt", "/HOME/USER/file.txt") is True


### PR DESCRIPTION
Makes the user-input containment check in path traversal detection case-insensitive, matching the fix applied to the Node.js firewall in AikidoSec/firewall-node#1047.

**Problem**: On case-insensitive filesystems (macOS APFS, Windows NTFS), an attacker can submit a path like `/ETC/PASSWD` which resolves to `/etc/passwd`. The detection check `user_input not in file_path` was case-sensitive, so `/ETC/PASSWD` would not be found in `/etc/passwd` and traversal would go undetected.

**Fix**: Changed `user_input not in file_path` to `user_input.lower() not in file_path.lower()`.

See: https://github.com/AikidoSec/firewall-node/pull/1047

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Made path containment check case-insensitive to detect traversal attacks


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124651005?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->