### PR TITLE
Fix NoSQL object comparison being too strict

### DIFF
--- a/aikido_zen/vulnerabilities/nosql_injection/__init__.py
+++ b/aikido_zen/vulnerabilities/nosql_injection/__init__.py
@@ -24,7 +24,7 @@ def match_filter_part_in_user(user_input, filter_part, path_to_payload=None):
 
     if is_mapping(user_input):
         filtered_input = remove_keys_that_dont_start_with_dollar_sign(user_input)
-        if filtered_input == filter_part:
+        if is_user_operators_subset_of(filtered_input, filter_part):
             return {
                 "match": True,
                 "pathToPayload": build_path_to_payload(path_to_payload),
@@ -55,6 +55,20 @@ def remove_keys_that_dont_start_with_dollar_sign(nosql_filter):
     This removes key that don't start with $, since they are not dangerous
     """
     return {key: value for key, value in nosql_filter.items() if key.startswith("$")}
+
+
+def is_user_operators_subset_of(user_operators, filter_operators):
+    """
+    Returns True if every operator in user_operators is present in filter_operators
+    with the same value — i.e. the user-supplied operators are a subset of the filter.
+    An empty user_operators dict never matches (no operators = no injection).
+    """
+    has_keys = False
+    for key, value in user_operators.items():
+        if key not in filter_operators or filter_operators[key] != value:
+            return False
+        has_keys = True
+    return has_keys
 
 
 def find_filter_part_with_operators(user_input, part_of_filter):

--- a/aikido_zen/vulnerabilities/nosql_injection/init_test.py
+++ b/aikido_zen/vulnerabilities/nosql_injection/init_test.py
@@ -540,3 +540,105 @@ def test_ignores_safe_pipeline_aggregations(create_context):
         )
         == {}
     )
+
+
+def test_detects_injection_when_app_merges_user_operators_with_own_dollar_keys(
+    create_context,
+):
+    assert detect_nosql_injection(
+        create_context(body={"username": {"$ne": None}}),
+        {"title": {"$ne": None, "$exists": True}},
+    ) == {
+        "injection": True,
+        "source": "body",
+        "pathToPayload": ".username",
+        "payload": {"$ne": None, "$exists": True},
+    }
+
+
+def test_detects_injection_when_app_prepends_own_dollar_key_before_user_operators(
+    create_context,
+):
+    assert detect_nosql_injection(
+        create_context(body={"username": {"$gt": ""}}),
+        {"title": {"$exists": True, "$gt": ""}},
+    ) == {
+        "injection": True,
+        "source": "body",
+        "pathToPayload": ".username",
+        "payload": {"$exists": True, "$gt": ""},
+    }
+
+
+def test_does_not_flag_when_user_operator_value_differs(create_context):
+    assert (
+        detect_nosql_injection(
+            create_context(body={"username": {"$ne": "different"}}),
+            {"title": {"$ne": None, "$exists": True}},
+        )
+        == {}
+    )
+
+
+def test_detects_injection_when_app_adds_non_dollar_key_to_subobject(create_context):
+    assert detect_nosql_injection(
+        create_context(body={"field": {"$elemMatch": {"$gt": 5}}}),
+        {"items": {"$elemMatch": {"$gt": 5, "verified": True}}},
+    ) == {
+        "injection": True,
+        "source": "body",
+        "pathToPayload": ".field.$elemMatch",
+        "payload": {"$gt": 5},
+    }
+
+
+def test_does_not_flag_when_user_sends_empty_object(create_context):
+    assert (
+        detect_nosql_injection(
+            create_context(body={"username": {}}),
+            {"title": {"$exists": True}},
+        )
+        == {}
+    )
+
+
+def test_does_not_flag_when_user_object_has_only_non_dollar_keys(create_context):
+    assert (
+        detect_nosql_injection(
+            create_context(body={"username": {"name": "alice"}}),
+            {"title": {"$exists": True}},
+        )
+        == {}
+    )
+
+
+def test_does_not_flag_when_user_dollar_key_absent_from_filter(create_context):
+    assert (
+        detect_nosql_injection(
+            create_context(body={"username": {"$ne": None}}),
+            {"title": {"$exists": True}},
+        )
+        == {}
+    )
+
+
+def test_does_not_flag_when_filter_uses_subset_of_user_operators(create_context):
+    assert (
+        detect_nosql_injection(
+            create_context(body={"username": {"$ne": None, "$gt": 0}}),
+            {"title": {"$ne": None}},
+        )
+        == {}
+    )
+
+
+def test_does_not_flag_when_app_ignores_user_operators_and_uses_hardcoded_filter(
+    create_context,
+):
+    assert (
+        detect_nosql_injection(
+            create_context(body={"username": {"$ne": None}}),
+            {"username": "hardcoded"},
+        )
+        == {}
+    )


### PR DESCRIPTION
Ports AikidoSec/firewall-node#1032 to Python.

**Problem**: The NoSQL injection detector used exact equality (`filtered_input == filter_part`) when comparing user-supplied `$` operators to the MongoDB filter. This caused false negatives when:
- The app merges user operators with its own (e.g. adds `$exists: true` alongside user's `$ne: null`)
- The app prepends its own `$` keys before the user's operators

**Fix**: Replace exact equality with `is_user_operators_subset_of()` — checks that every user-supplied operator exists in the filter with the same value, instead of requiring the objects to be identical. An empty operator dict never matches.

All 9 new test cases from the Node.js PR are ported.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added is_user_operators_subset_of helper to compare operator subsets accurately

**🐛 Bugfixes**
* Relaxed NoSQL operator comparison to allow subset matches


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124670161?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->