### PR TITLE
Fix background process socket race

### DIFF
--- a/aikido_zen/background_process/__init__.py
+++ b/aikido_zen/background_process/__init__.py
@@ -43,7 +43,11 @@ def start_background_process():
     if isinstance(address, str) and os.path.exists(address):
         if background_process_already_active(comms):
             return  # Don't start if the background process is already active
-        os.remove(address)
+        try:
+            os.remove(address)
+        except FileNotFoundError:
+            # Another application worker removed the stale socket first.
+            pass
 
     #  Daemon is set to True so that the process kills itself when the main process dies
     background_process = Process(

--- a/aikido_zen/background_process/init_test.py
+++ b/aikido_zen/background_process/init_test.py
@@ -1,0 +1,23 @@
+import aikido_zen.background_process as background_process
+
+
+def test_stale_socket_removed_by_another_worker(monkeypatch, mocker):
+    process = mocker.patch("aikido_zen.background_process.Process")
+    monkeypatch.setenv("AIKIDO_TOKEN", "AIK_RUNTIME_TEST")
+    monkeypatch.setattr(background_process.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        background_process, "get_uds_filename", lambda: "/tmp/aikido.sock"
+    )
+    monkeypatch.setattr(background_process.os.path, "exists", lambda _path: True)
+    monkeypatch.setattr(
+        background_process, "background_process_already_active", lambda _comms: False
+    )
+    monkeypatch.setattr(
+        background_process.os,
+        "remove",
+        mocker.Mock(side_effect=FileNotFoundError),
+    )
+
+    background_process.start_background_process()
+
+    process.return_value.start.assert_called_once_with()


### PR DESCRIPTION
## What changed

- Tolerate `FileNotFoundError` when removing a stale Unix-domain socket.
- Add a regression test covering another application worker winning the cleanup race.

## Why

Multiple Gunicorn workers can call `start_background_process()` concurrently. They may both observe the stale socket and determine that no background process is active, after which the first worker removes the socket and the second worker raises `FileNotFoundError`. Because this happens while the application is loading, the affected Gunicorn worker fails to boot.

The background process listener is already exclusive and makes any duplicate process attempt exit cleanly, so treating an already-removed stale socket as successful cleanup is sufficient.

## Impact

Concurrent worker startup no longer fails because another worker removed the stale IPC socket first.

## Validation

- Focused background-process tests: 4 passed
- Background-process test area: 160 passed; 3 integration tests require the repository's local HTTP test server on port 5050
- Black: passed
- Pylint: 10.00/10


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Caught FileNotFoundError when removing stale UDS socket during startup


<sup>[More info](https://app.aikido.dev/featurebranch/scan/153217110?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->